### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/tests/test_meetup_event.py
+++ b/tests/test_meetup_event.py
@@ -123,7 +123,7 @@ def test_featured_missing(free_meetup_event):
     assert not free_meetup_event.featured
 
 
-def test_featured_missing(paid_meetup_event):
+def test_featured_missing_two(paid_meetup_event):
     """Test getting the featured flag."""
     assert paid_meetup_event.featured
 


### PR DESCRIPTION
Fixes #1.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

